### PR TITLE
update the goal prefix to be fully qualified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <id>mjiderhamn</id>
       <name>Mattias Jiderhamn</name>
     </developer>
-  </developers>   
+  </developers>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -96,6 +96,12 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/src/main/java/se/jiderhamn/promote/maven/plugin/PromoteUtils.java
+++ b/src/main/java/se/jiderhamn/promote/maven/plugin/PromoteUtils.java
@@ -23,7 +23,7 @@ import static org.codehaus.plexus.util.StringUtils.isBlank;
 class PromoteUtils {
 
   /** Prefix to use when configuring goals programatically */
-  public static final String GOAL_PREFIX = "promote:"; // "se.jiderhamn:promote:";
+  public static final String GOAL_PREFIX = getGoalPrefix(); // "se.jiderhamn:promote-maven-plugin:2.0.2-SNAPSHOT:promote:";
 
   /** File in which artifact information is stored between the build and the promotion */
   static final String FILENAME = "promotable-artifacts.properties";
@@ -32,6 +32,17 @@ class PromoteUtils {
   public static final String RELEASE_VERSION = "releaseVersion";
 
   private PromoteUtils() {}
+
+  private static String getGoalPrefix() {
+    String propertiesFileName = "promote-maven-plugin.properties";
+    try {
+      Properties properties = new Properties();
+      properties.load(PromoteUtils.class.getClassLoader().getResourceAsStream(propertiesFileName));
+      return String.format("%s:%s:%s:", properties.get("groupId"), properties.get("artifactId"), properties.get("version"));
+    } catch (IOException e) {
+      throw new RuntimeException("Could not load properties. " + propertiesFileName);
+    }
+  }
 
   static Map<String, String> toMap(Artifact artifact, String prefix, URI basePath) {
     prefix = fixPrefix(prefix);
@@ -55,20 +66,20 @@ class PromoteUtils {
 
     return output;
   }
-  
+
   /** Parse list of attached {@link Artifact}s from {@link Properties} */
   static List<Artifact> attachedArtifactsFromProperties(Properties props, URI basePath) {
     List<Artifact> output = new ArrayList<Artifact>();
-    
+
     for(int i = 0; ; i++) {
       Artifact attachedArtifact = PromoteUtils.fromProperties(props, "attached." + i, basePath);
       if(attachedArtifact != null) {
         output.add(attachedArtifact);
       }
-      else 
+      else
         break; // No more attached artifacts
     }
-    
+
     return output;
   }
 

--- a/src/main/resources/promote-maven-plugin.properties
+++ b/src/main/resources/promote-maven-plugin.properties
@@ -1,0 +1,3 @@
+groupId=${project.groupId}
+artifactId=${project.artifactId}
+version=${project.version}


### PR DESCRIPTION
By using a fully qualified goal prefix, this should allow this plugin to function without actually having to include it as a plugin in the pom. This can be useful to help separate concerns when it comes to CI. The CI configuration can handle special promotion stuff when it invokes maven rather than baking it into the maven lifecycle directly.